### PR TITLE
Use Optional In Cache To Keep Track of Errors Generating Moosifications.

### DIFF
--- a/src/main/java/org/sexyideas/moosificator/MoosificatorApp.java
+++ b/src/main/java/org/sexyideas/moosificator/MoosificatorApp.java
@@ -15,7 +15,7 @@ import javax.ws.rs.ApplicationPath;
 @ApplicationPath("/")
 public class MoosificatorApp extends ResourceConfig {
     public MoosificatorApp() {
-        registerClasses(MooseResource.class);
+        register(MooseResource.class);
         KeenClient.initialize();
     }
 


### PR DESCRIPTION
@timoman: Better handling of errors in regards to the caching.
Also, errors generating moosifications will now be tracked as events in Keen IO.
